### PR TITLE
Fix: Remove lcov.info from repository and add to .gitignore


### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+coverage/lcov.info


### PR DESCRIPTION
### **User description**
Removes the coverage/lcov.info file from the repository tracking and adds it to the .gitignore file to prevent future commits. This file is a build artifact and should not be part of the repository.

Coverage reports should be uploaded via CI tools instead of being stored in the repository.


___

### **PR Type**
Bug fix


___

### **Description**
• Remove `coverage/lcov.info` file from repository tracking as it's a build artifact
• Add `lcov.info` to `.gitignore` to prevent future commits of coverage reports
• Ensure coverage reports are handled via CI tools rather than stored in repository


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>